### PR TITLE
Fixed undefined ATOM_HOME.

### DIFF
--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -21,6 +21,7 @@ module.exports = ({blobStore}) ->
 
   AtomEnvironment = require './atom-environment'
   ApplicationDelegate = require './application-delegate'
+  !process.env.ATOM_HOME && (process.env.ATOM_HOME = process.env.HOME && path.join(process.env.HOME, '.atom') || '');
   window.atom = new AtomEnvironment({
     window, document, blobStore,
     applicationDelegate: new ApplicationDelegate,


### PR DESCRIPTION
`ATOM_HOME` is `undefined`, which breaks Atom on startup (at least on Mac). Interesting that it is `undefined` even when I explicitly set this variable in `.bashrc`. The patch is a one-liner for simplicity:

* It checks, if `ATOM_HOME` is falsy. If it is:
  * It checks if `HOME` is truthy. If it is:
    * It sets `ATOM_HOME` to `path.join(HOME, '.atom')`.
  * Otherwise it sets it to an empty string.

The description above dwarves the code.

I don't know what caused the problem, because I saw it before intermittently, but recently I updated node to 6.3.0, and Mac to 10.11.6. The combined change made the problem persistent.

Before debugging the code I tried to reinstall Atom 1.8.0, and 1.9.0-beta0 &mdash; both fail the same way (`undefined` is passed to `path.join()`).